### PR TITLE
Pass secrets via environment variables

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,11 @@ This changelog contains the changes made between releases. The versioning follow
 
 ## Unreleased
 
+### Added
+
+- Support for battery and RF-link status
+- Support for configuration via environment variables
+
 ## 1.1.0 (2018-09-02)
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -38,6 +38,18 @@ Usage of netatmo-exporter:
 
 After starting the server will offer the metrics on the `/metrics` endpoint, which can be used as a target for prometheus.
 
+### Passing secrets
+
+You can pass credentials either via command line arguments (see next section) or by populating the following environment variables:
+
+* `NETATMO_EXPORTER_ADDR` Address to listen on
+* `NETATMO_CLIENT_ID` Client ID for NetAtmo app
+* `NETATMO_CLIENT_SECRET` Client secret for NetAtmo app
+* `NETATMO_CLIENT_USERNAME` Username of NetAtmo account
+* `NETATMO_CLIENT_PASSWORD` Password of NetAtmo account
+
+### Scrape interval
+
 The exporter will query the Netatmo API every time it is scraped by prometheus. It does not make sense to scrape the Netatmo API with a small interval as the sensors only update their data every few minutes, so don't forget to set a slower scrape interval for this exporter:
 
 ```yml
@@ -47,4 +59,3 @@ scrape_configs:
     static_configs:
       - targets: ['localhost:9210']
 ```
-

--- a/main.go
+++ b/main.go
@@ -4,6 +4,7 @@ import (
 	"errors"
 	"log"
 	"net/http"
+	"os"
 
 	netatmo "github.com/exzz/netatmo-api-go"
 	"github.com/prometheus/client_golang/prometheus"
@@ -17,11 +18,18 @@ type config struct {
 
 func parseConfig() (config, error) {
 	cfg := config{}
-	pflag.StringVarP(&cfg.Addr, "addr", "a", ":9210", "Address to listen on.")
-	pflag.StringVarP(&cfg.Netatmo.ClientID, "client-id", "i", "", "Client ID for NetAtmo app.")
-	pflag.StringVarP(&cfg.Netatmo.ClientSecret, "client-secret", "s", "", "Client secret for NetAtmo app.")
-	pflag.StringVarP(&cfg.Netatmo.Username, "username", "u", "", "Username of NetAtmo account.")
-	pflag.StringVarP(&cfg.Netatmo.Password, "password", "p", "", "Password of NetAtmo account.")
+
+	// Set default port to bind to
+	addr := ":9210"
+	if envAddr := os.Getenv("NETATMO_EXPORTER_ADDR"); envAddr != "" {
+		addr = envAddr
+	}
+
+	pflag.StringVarP(&cfg.Addr, "addr", "a", addr, "Address to listen on.")
+	pflag.StringVarP(&cfg.Netatmo.ClientID, "client-id", "i", os.Getenv("NETATMO_CLIENT_ID"), "Client ID for NetAtmo app.")
+	pflag.StringVarP(&cfg.Netatmo.ClientSecret, "client-secret", "s", os.Getenv("NETATMO_CLIENT_SECRET"), "Client secret for NetAtmo app.")
+	pflag.StringVarP(&cfg.Netatmo.Username, "username", "u", os.Getenv("NETATMO_CLIENT_USERNAME"), "Username of NetAtmo account.")
+	pflag.StringVarP(&cfg.Netatmo.Password, "password", "p", os.Getenv("NETATMO_CLIENT_PASSWORD"), "Password of NetAtmo account.")
 	pflag.Parse()
 
 	if len(cfg.Addr) == 0 {


### PR DESCRIPTION
In order to not show sensitive information (login, password, API keys etc...) I've added basic support for passing the following informations via environment variables:
 * Client ID
 * Client Secret
 * NetAtmo username
 * NetAtmo password

If no environment variable is set, then it defaults to using whatever is passed on the command line.