### PR TITLE
Switch to API fork and update parsed data

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,11 @@ This changelog contains the changes made between releases. The versioning follow
 ### Added
 
 - Debugging endpoint for looking at data read from NetAtmo API (`/debug/data`)
+- New `home` label as additional identification for sensors
+
+### Changed
+
+- Switch to fork of netatmo-api-go library
 
 ## [1.4.0] - 2022-04-02
 

--- a/go.mod
+++ b/go.mod
@@ -24,3 +24,5 @@ require (
 	github.com/prometheus/common v0.37.0 // indirect
 	google.golang.org/protobuf v1.28.1 // indirect
 )
+
+replace github.com/exzz/netatmo-api-go => github.com/xperimental/netatmo-api-go v0.0.0-20220918192520-fb6577104ce6

--- a/go.sum
+++ b/go.sum
@@ -58,8 +58,6 @@ github.com/envoyproxy/go-control-plane v0.9.0/go.mod h1:YTl/9mNaCwkRvm6d1a2C3ymF
 github.com/envoyproxy/go-control-plane v0.9.1-0.20191026205805-5f8ba28d4473/go.mod h1:YTl/9mNaCwkRvm6d1a2C3ymFceY/DCBVvsKhRF0iEA4=
 github.com/envoyproxy/go-control-plane v0.9.4/go.mod h1:6rpuAdCZL397s3pYoYcLgu1mIlRU8Am5FuJP05cCM98=
 github.com/envoyproxy/protoc-gen-validate v0.1.0/go.mod h1:iSmxcyjqTsJpI2R4NaDN7+kN2VEUnK/pcBlmesArF7c=
-github.com/exzz/netatmo-api-go v0.0.0-20201009073308-a8620474d1ea h1:VqmvDr/j/PUDYN9j5oMXcguiJT/bA/kh/wdcGDrdZYs=
-github.com/exzz/netatmo-api-go v0.0.0-20201009073308-a8620474d1ea/go.mod h1:Rlj3fFpyVYt+Fghy6vdSrKCkO/QjjWCJC4mTfcxDYqM=
 github.com/go-gl/glfw v0.0.0-20190409004039-e6da0acd62b1/go.mod h1:vR7hzQXu2zJy9AVAgeJqvqgH9Q5CA+iKCZ2gyEVpxRU=
 github.com/go-gl/glfw/v3.3/glfw v0.0.0-20191125211704-12ad95a8df72/go.mod h1:tQ2UAYgL5IevRw8kRxooKSPJfGvJ9fJQFa0TUsXzTg8=
 github.com/go-gl/glfw/v3.3/glfw v0.0.0-20200222043503-6f7a984d4dc4/go.mod h1:tQ2UAYgL5IevRw8kRxooKSPJfGvJ9fJQFa0TUsXzTg8=
@@ -200,6 +198,8 @@ github.com/stretchr/testify v1.3.0/go.mod h1:M5WIy9Dh21IEIfnGCwXGc5bZfKNJtfHm1UV
 github.com/stretchr/testify v1.4.0/go.mod h1:j7eGeouHqKxXV5pUuKE4zz7dFj8WfuZ+81PSLYec5m4=
 github.com/stretchr/testify v1.7.0 h1:nwc3DEeHmmLAfoZucVR881uASk0Mfjw8xYJ99tb5CcY=
 github.com/stretchr/testify v1.7.0/go.mod h1:6Fq8oRcR53rry900zMqJjRRixrwX3KX962/h/Wwjteg=
+github.com/xperimental/netatmo-api-go v0.0.0-20220918192520-fb6577104ce6 h1:Qa1paNybNoZKVRMl/sk2f0qigGxbHjlNvs5/J8mrHgY=
+github.com/xperimental/netatmo-api-go v0.0.0-20220918192520-fb6577104ce6/go.mod h1:6OMZxfbY7EZh+Q5qn/cPrRgCp+HRyBld5w05JzX8ddA=
 github.com/yuin/goldmark v1.1.25/go.mod h1:3hX8gzYuyVAZsxl0MRgGTJEmQBFcNTphYh9decYSb74=
 github.com/yuin/goldmark v1.1.27/go.mod h1:3hX8gzYuyVAZsxl0MRgGTJEmQBFcNTphYh9decYSb74=
 github.com/yuin/goldmark v1.1.32/go.mod h1:3hX8gzYuyVAZsxl0MRgGTJEmQBFcNTphYh9decYSb74=

--- a/internal/collector/collector.go
+++ b/internal/collector/collector.go
@@ -161,7 +161,7 @@ func (c *NetatmoCollector) Collect(mChan chan<- prometheus.Metric) {
 	if c.cachedData != nil {
 		for _, dev := range c.cachedData.Devices() {
 			homeName := dev.HomeName
-			stationName := dev.StationName
+			stationName := dev.StationName //nolint: staticcheck
 			c.collectData(mChan, dev, stationName, homeName)
 
 			for _, module := range dev.LinkedModules {

--- a/internal/collector/collector.go
+++ b/internal/collector/collector.go
@@ -37,6 +37,7 @@ var (
 	varLabels = []string{
 		"module",
 		"station",
+		"home",
 	}
 
 	sensorPrefix = prefix + "sensor_"
@@ -159,11 +160,12 @@ func (c *NetatmoCollector) Collect(mChan chan<- prometheus.Metric) {
 	c.sendMetric(mChan, cacheTimestampDesc, prometheus.GaugeValue, convertTime(c.cacheTimestamp))
 	if c.cachedData != nil {
 		for _, dev := range c.cachedData.Devices() {
+			homeName := dev.HomeName
 			stationName := dev.StationName
-			c.collectData(mChan, dev, stationName)
+			c.collectData(mChan, dev, stationName, homeName)
 
 			for _, module := range dev.LinkedModules {
-				c.collectData(mChan, module, stationName)
+				c.collectData(mChan, module, stationName, homeName)
 			}
 		}
 	}
@@ -191,7 +193,7 @@ func (c *NetatmoCollector) RefreshData(now time.Time) {
 	c.cachedData = devices
 }
 
-func (c *NetatmoCollector) collectData(ch chan<- prometheus.Metric, device *netatmo.Device, stationName string) {
+func (c *NetatmoCollector) collectData(ch chan<- prometheus.Metric, device *netatmo.Device, stationName, homeName string) {
 	moduleName := device.ModuleName
 	data := device.DashboardData
 
@@ -206,48 +208,48 @@ func (c *NetatmoCollector) collectData(ch chan<- prometheus.Metric, device *neta
 		return
 	}
 
-	c.sendMetric(ch, updatedDesc, prometheus.GaugeValue, float64(date.UTC().Unix()), moduleName, stationName)
+	c.sendMetric(ch, updatedDesc, prometheus.GaugeValue, float64(date.UTC().Unix()), moduleName, stationName, homeName)
 
 	if data.Temperature != nil {
-		c.sendMetric(ch, tempDesc, prometheus.GaugeValue, float64(*data.Temperature), moduleName, stationName)
+		c.sendMetric(ch, tempDesc, prometheus.GaugeValue, float64(*data.Temperature), moduleName, stationName, homeName)
 	}
 
 	if data.Humidity != nil {
-		c.sendMetric(ch, humidityDesc, prometheus.GaugeValue, float64(*data.Humidity), moduleName, stationName)
+		c.sendMetric(ch, humidityDesc, prometheus.GaugeValue, float64(*data.Humidity), moduleName, stationName, homeName)
 	}
 
 	if data.CO2 != nil {
-		c.sendMetric(ch, cotwoDesc, prometheus.GaugeValue, float64(*data.CO2), moduleName, stationName)
+		c.sendMetric(ch, cotwoDesc, prometheus.GaugeValue, float64(*data.CO2), moduleName, stationName, homeName)
 	}
 
 	if data.Noise != nil {
-		c.sendMetric(ch, noiseDesc, prometheus.GaugeValue, float64(*data.Noise), moduleName, stationName)
+		c.sendMetric(ch, noiseDesc, prometheus.GaugeValue, float64(*data.Noise), moduleName, stationName, homeName)
 	}
 
 	if data.Pressure != nil {
-		c.sendMetric(ch, pressureDesc, prometheus.GaugeValue, float64(*data.Pressure), moduleName, stationName)
+		c.sendMetric(ch, pressureDesc, prometheus.GaugeValue, float64(*data.Pressure), moduleName, stationName, homeName)
 	}
 
 	if data.WindStrength != nil {
-		c.sendMetric(ch, windStrengthDesc, prometheus.GaugeValue, float64(*data.WindStrength), moduleName, stationName)
+		c.sendMetric(ch, windStrengthDesc, prometheus.GaugeValue, float64(*data.WindStrength), moduleName, stationName, homeName)
 	}
 
 	if data.WindAngle != nil {
-		c.sendMetric(ch, windDirectionDesc, prometheus.GaugeValue, float64(*data.WindAngle), moduleName, stationName)
+		c.sendMetric(ch, windDirectionDesc, prometheus.GaugeValue, float64(*data.WindAngle), moduleName, stationName, homeName)
 	}
 
 	if data.Rain != nil {
-		c.sendMetric(ch, rainDesc, prometheus.GaugeValue, float64(*data.Rain), moduleName, stationName)
+		c.sendMetric(ch, rainDesc, prometheus.GaugeValue, float64(*data.Rain), moduleName, stationName, homeName)
 	}
 
 	if device.BatteryPercent != nil {
-		c.sendMetric(ch, batteryDesc, prometheus.GaugeValue, float64(*device.BatteryPercent), moduleName, stationName)
+		c.sendMetric(ch, batteryDesc, prometheus.GaugeValue, float64(*device.BatteryPercent), moduleName, stationName, homeName)
 	}
 	if device.WifiStatus != nil {
-		c.sendMetric(ch, wifiDesc, prometheus.GaugeValue, float64(*device.WifiStatus), moduleName, stationName)
+		c.sendMetric(ch, wifiDesc, prometheus.GaugeValue, float64(*device.WifiStatus), moduleName, stationName, homeName)
 	}
 	if device.RFStatus != nil {
-		c.sendMetric(ch, rfDesc, prometheus.GaugeValue, float64(*device.RFStatus), moduleName, stationName)
+		c.sendMetric(ch, rfDesc, prometheus.GaugeValue, float64(*device.RFStatus), moduleName, stationName, homeName)
 	}
 }
 


### PR DESCRIPTION
Switches the API used to [xperimental/netatmo-api-go on branch "new-api"](https://github.com/xperimental/netatmo-api-go).

The `StationName` field has been deprecated in the API, `HomeName` and `ModuleName` should be used instead. The `HomeName` has been added as an additional label called `home`. This should fix issues with empty `station` label and related crashes.

