### PR TITLE
Change behavior of Docker tags

### DIFF
--- a/.github/workflows/package.yml
+++ b/.github/workflows/package.yml
@@ -6,6 +6,9 @@ on:
   release:
     types:
     - published
+  pull_request:
+    branches:
+    - master
 jobs:
   test:
     runs-on: ubuntu-latest
@@ -28,23 +31,28 @@ jobs:
       uses: actions/checkout@v3
       with:
         fetch-depth: 0
-    - name: Set up QEMU
-      uses: docker/setup-qemu-action@v1
-    - name: Set up Docker Buildx
-      id: buildx
-      uses: docker/setup-buildx-action@v1
+    - name: Docker Metadata
+      id: meta
+      uses: docker/metadata-action@v4
+      with:
+        images: |
+          ghcr.io/xperimental/netatmo-exporter
+          xperimental/netatmo-exporter
     - name: Login to GitHub Container Registry
-      uses: docker/login-action@v1
+      uses: docker/login-action@v2
       with:
         registry: ghcr.io
         username: ${{ github.actor }}
         password: ${{ secrets.GITHUB_TOKEN }}
     - name: Login to Docker hub
-      uses: docker/login-action@v1
+      uses: docker/login-action@v2
       with:
         username: xperimental
         password: ${{ secrets.DOCKER_TOKEN }}
-    - name: Build image
-      run: make all-images
-      env:
-        GITHUB_REF: ${{ github.ref }}
+    - name: Build and push Docker images
+      uses: docker/build-push-action@v3
+      with:
+        context: .
+        #push: ${{ github.event_name != 'pull_request' }}
+        tags: ${{ steps.meta.outputs.tags }}
+        labels: ${{ steps.meta.outputs.labels }}

--- a/.github/workflows/package.yml
+++ b/.github/workflows/package.yml
@@ -38,6 +38,10 @@ jobs:
         images: |
           ghcr.io/xperimental/netatmo-exporter
           xperimental/netatmo-exporter
+        tags: |
+          type=semver,pattern={{version}}
+          type=ref,event=branch
+          type=ref,event=pr
     - name: Login to GitHub Container Registry
       uses: docker/login-action@v2
       with:

--- a/.github/workflows/package.yml
+++ b/.github/workflows/package.yml
@@ -61,7 +61,7 @@ jobs:
       uses: docker/build-push-action@v3
       with:
         context: .
-        #push: ${{ github.event_name != 'pull_request' }}
+        push: ${{ github.event_name != 'pull_request' }}
         tags: ${{ steps.meta.outputs.tags }}
         labels: ${{ steps.meta.outputs.labels }}
         platforms: linux/amd64,linux/arm64

--- a/.github/workflows/package.yml
+++ b/.github/workflows/package.yml
@@ -64,3 +64,4 @@ jobs:
         #push: ${{ github.event_name != 'pull_request' }}
         tags: ${{ steps.meta.outputs.tags }}
         labels: ${{ steps.meta.outputs.labels }}
+        platforms: linux/amd64,linux/arm64

--- a/.github/workflows/package.yml
+++ b/.github/workflows/package.yml
@@ -31,17 +31,10 @@ jobs:
       uses: actions/checkout@v3
       with:
         fetch-depth: 0
-    - name: Docker Metadata
-      id: meta
-      uses: docker/metadata-action@v4
-      with:
-        images: |
-          ghcr.io/xperimental/netatmo-exporter
-          xperimental/netatmo-exporter
-        tags: |
-          type=semver,pattern={{version}}
-          type=ref,event=branch
-          type=ref,event=pr
+    - name: Set up QEMU
+      uses: docker/setup-qemu-action@v2
+    - name: Set up Docker Buildx
+      uses: docker/setup-buildx-action@v2
     - name: Login to GitHub Container Registry
       uses: docker/login-action@v2
       with:
@@ -53,6 +46,17 @@ jobs:
       with:
         username: xperimental
         password: ${{ secrets.DOCKER_TOKEN }}
+    - name: Docker Metadata
+      id: meta
+      uses: docker/metadata-action@v4
+      with:
+        images: |
+          ghcr.io/xperimental/netatmo-exporter
+          xperimental/netatmo-exporter
+        tags: |
+          type=semver,pattern={{version}}
+          type=ref,event=branch
+          type=ref,event=pr
     - name: Build and push Docker images
       uses: docker/build-push-action@v3
       with:

--- a/.github/workflows/pull-request.yml
+++ b/.github/workflows/pull-request.yml
@@ -4,19 +4,6 @@ on:
     branches:
     - master
 jobs:
-  test:
-    runs-on: ubuntu-latest
-    steps:
-    - name: Checkout
-      uses: actions/checkout@v3
-      with:
-        fetch-depth: 0
-    - name: Setup Go
-      uses: actions/setup-go@v3
-      with:
-        go-version-file: go.mod
-    - name: Build and Test
-      run: make
   lint:
     runs-on: ubuntu-latest
     steps:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ This changelog contains the changes made between releases. The versioning follow
 
 ## Unreleased
 
+### Changed
+
+- `latest` Docker tag now points to most recent release and `master` points to the build from the default branch
+
 ## [1.5.0] - 2022-12-06
 
 ### Added

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,10 @@
-FROM golang:1.19.3-alpine AS builder
+FROM --platform=$BUILDPLATFORM golang:1.19.3-alpine AS builder
+
+ARG TARGETOS
+ARG TARGETARCH
+
+ENV GOOS=$TARGETOS
+ENV GOARCH=$TARGETARCH
 
 RUN apk add --no-cache make git bash
 
@@ -11,7 +17,7 @@ RUN go mod verify
 COPY . /build/
 RUN make build-binary
 
-FROM busybox
+FROM --platform=$TARGETPLATFORM busybox
 LABEL maintainer="Robert Jacob <xperimental@solidproject.de>"
 
 COPY --from=builder /etc/ssl/certs/ca-certificates.crt /etc/ssl/certs/ca-certificates.crt

--- a/Dockerfile
+++ b/Dockerfile
@@ -9,7 +9,7 @@ RUN go mod download
 RUN go mod verify
 
 COPY . /build/
-RUN make
+RUN make build-binary
 
 FROM busybox
 LABEL maintainer="Robert Jacob <xperimental@solidproject.de>"

--- a/Makefile
+++ b/Makefile
@@ -4,12 +4,8 @@ GO_CMD := CGO_ENABLED=0 $(GO)
 GIT_VERSION := $(shell git describe --tags --dirty)
 VERSION := $(GIT_VERSION:v%=%)
 GIT_COMMIT := $(shell git rev-parse HEAD)
-GITHUB_REF ?= refs/heads/master
-DOCKER_TAG != if [[ "$(GITHUB_REF)" == "refs/heads/master" ]]; then \
-		echo "latest"; \
-	else \
-		echo "$(VERSION)"; \
-	fi
+DOCKER_REPO ?= xperimental/netatmo-exporter
+DOCKER_TAG ?= dev
 
 .PHONY: all
 all: test build-binary
@@ -28,11 +24,11 @@ build-binary:
 
 .PHONY: image
 image:
-	docker buildx build -t "xperimental/netatmo-exporter:$(DOCKER_TAG)" --load .
+	docker buildx build -t "ghcr.io/$(DOCKER_REPO):$(DOCKER_TAG)" --load .
 
 .PHONY: all-images
 all-images:
-	docker buildx build -t "ghcr.io/xperimental/netatmo-exporter:$(DOCKER_TAG)" -t "xperimental/netatmo-exporter:$(DOCKER_TAG)" --platform linux/amd64,linux/arm64 --push .
+	docker buildx build -t "ghcr.io/$(DOCKER_REPO):$(DOCKER_TAG)" -t "docker.io/$(DOCKER_REPO):$(DOCKER_TAG)" --platform linux/amd64,linux/arm64 --push .
 
 .PHONY: clean
 clean:

--- a/README.md
+++ b/README.md
@@ -11,7 +11,11 @@ The exporter is available as a Docker image both on DockerHub and GitHub:
 - [`ghcr.io/xperimental/netatmo-exporter`](https://github.com/xperimental/netatmo-exporter/pkgs/container/netatmo-exporter)
 - [`xperimental/netatmo-exporter`](https://hub.docker.com/r/xperimental/netatmo-exporter/)
 
-In addition to the `latest` tag which points to the version currently in the `master` branch, tagged versions are also available.
+The following tags are available:
+
+- `x.y.z` pointing to the release with that version
+- `latest` pointing to the most recent released version
+- `master` pointing to the latest build from the default branch
 
 ### Build from source
 


### PR DESCRIPTION
This changes the behavior of the Docker tags to the following schema:

- `master` will refer to the latest build from the default branch
- Versions `x.y.z` will refer to the build for that released version
- `latest` will point to the latest released version

Effectively this adds a `master` tag to replace the current `latest` tag and makes `latest` point to the latest release instead. The aim of this is to make usage of `latest` more stable.