### PR TITLE
Save token when it is refreshed

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -8,7 +8,7 @@ require (
 	github.com/prometheus/client_golang v1.17.0
 	github.com/sirupsen/logrus v1.9.3
 	github.com/spf13/pflag v1.0.5
-	golang.org/x/oauth2 v0.22.0
+	golang.org/x/oauth2 v0.23.0
 )
 
 require (
@@ -24,4 +24,4 @@ require (
 	google.golang.org/protobuf v1.31.0 // indirect
 )
 
-replace github.com/exzz/netatmo-api-go => github.com/xperimental/netatmo-api-go v0.0.0-20220927234935-2a059c20f221
+replace github.com/exzz/netatmo-api-go => github.com/xperimental/netatmo-api-go v0.0.0-20241013210700-5e7f333f57e8

--- a/go.sum
+++ b/go.sum
@@ -31,10 +31,10 @@ github.com/spf13/pflag v1.0.5/go.mod h1:McXfInJRrz4CZXVZOBLb0bTZqETkiAhM9Iw0y3An
 github.com/stretchr/objx v0.1.0/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+wExME=
 github.com/stretchr/testify v1.7.0 h1:nwc3DEeHmmLAfoZucVR881uASk0Mfjw8xYJ99tb5CcY=
 github.com/stretchr/testify v1.7.0/go.mod h1:6Fq8oRcR53rry900zMqJjRRixrwX3KX962/h/Wwjteg=
-github.com/xperimental/netatmo-api-go v0.0.0-20220927234935-2a059c20f221 h1:LUYfr5cWfISCy/zxiz3vabUkH6iLSRTkRtsRDma607Q=
-github.com/xperimental/netatmo-api-go v0.0.0-20220927234935-2a059c20f221/go.mod h1:6OMZxfbY7EZh+Q5qn/cPrRgCp+HRyBld5w05JzX8ddA=
-golang.org/x/oauth2 v0.22.0 h1:BzDx2FehcG7jJwgWLELCdmLuxk2i+x9UDpSiss2u0ZA=
-golang.org/x/oauth2 v0.22.0/go.mod h1:XYTD2NtWslqkgxebSiOHnXEap4TF09sJSc7H1sXbhtI=
+github.com/xperimental/netatmo-api-go v0.0.0-20241013210700-5e7f333f57e8 h1:U7Kjez/H8bg/1/IqKcSF7ypfTw/nfO19H4chk8Z7sRo=
+github.com/xperimental/netatmo-api-go v0.0.0-20241013210700-5e7f333f57e8/go.mod h1:+Vj12rSUvfxn8lgFGlxHmymmLdUR/3qkp6fG9r2UHGk=
+golang.org/x/oauth2 v0.23.0 h1:PbgcYx2W7i4LvjJWEbf0ngHV6qJYr86PkAV3bXdLEbs=
+golang.org/x/oauth2 v0.23.0/go.mod h1:XYTD2NtWslqkgxebSiOHnXEap4TF09sJSc7H1sXbhtI=
 golang.org/x/sync v0.0.0-20181221193216-37e7f081c4d4/go.mod h1:RxMgew5VJxzue5/jJTE5uejpjVlOe/izrB70Jof72aM=
 golang.org/x/sys v0.0.0-20220715151400-c0bba94af5f8/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/sys v0.13.0 h1:Af8nKPmuFypiUBjVoU9V20FiaFXOcuZI21p0ycVYYGE=

--- a/main.go
+++ b/main.go
@@ -10,13 +10,13 @@ import (
 	"syscall"
 	"time"
 
-	"github.com/exzz/netatmo-api-go"
 	"github.com/prometheus/client_golang/prometheus"
 	"github.com/prometheus/client_golang/prometheus/promhttp"
 	"github.com/sirupsen/logrus"
 	"github.com/spf13/pflag"
 	"golang.org/x/oauth2"
 
+	"github.com/exzz/netatmo-api-go"
 	"github.com/xperimental/netatmo-exporter/v2/internal/collector"
 	"github.com/xperimental/netatmo-exporter/v2/internal/config"
 	"github.com/xperimental/netatmo-exporter/v2/internal/logger"
@@ -44,7 +44,7 @@ func main() {
 	}
 	log.SetLevel(logrus.Level(cfg.LogLevel))
 
-	client := netatmo.NewClient(cfg.Netatmo)
+	client := netatmo.NewClient(cfg.Netatmo, tokenUpdated(cfg.TokenFile))
 
 	if cfg.TokenFile != "" {
 		token, err := loadToken(cfg.TokenFile)
@@ -127,6 +127,20 @@ func registerSignalHandler(client *netatmo.Client, fileName string) {
 	}()
 }
 
+func tokenUpdated(fileName string) netatmo.TokenUpdateFunc {
+	if fileName == "" {
+		return nil
+	}
+
+	return func(token *oauth2.Token) {
+		log.Debugf("Token updated. Expires: %s", token.Expiry)
+
+		if err := saveTokenFile(fileName, token); err != nil {
+			log.Errorf("Error saving token: %s", err)
+		}
+	}
+}
+
 func saveToken(client *netatmo.Client, fileName string) error {
 	token, err := client.CurrentToken()
 	switch {
@@ -138,6 +152,10 @@ func saveToken(client *netatmo.Client, fileName string) error {
 	}
 
 	log.Infof("Saving token to %s ...", fileName)
+	return saveTokenFile(fileName, token)
+}
+
+func saveTokenFile(fileName string, token *oauth2.Token) error {
 	data, err := json.Marshal(token)
 	if err != nil {
 		return fmt.Errorf("error marshalling token: %w", err)


### PR DESCRIPTION
Fixes #54 

This adds a feature that has been requested a few times: the exporter should not only save the token when shutting down but also while it is running. The current implementation will save the token every time it is refreshed.

@szermatt I don't think I re-used any of the code in your branches, but I decided to mention your name anyway, because you made the effort and our ideas were so similar :slightly_smiling_face: 

I've also build a testing image, which is available at `ghcr.io/xperimental/netatmo-exporter:save-token`. I'll let that marinate on my installation for a bit to see if this actually works.

