### PR TITLE
Added the Netatmo Thermostat status

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,6 +32,21 @@ Example in Grafana
 <img width="1796" height="1568" alt="510765545-ce94b4f1-3b09-426e-8713-eb90682ed892" src="https://github.com/user-attachments/assets/50103055-3fd8-4804-9980-a86d192dd222" />
 
 
+## Docker
+
+It should works also using Docker, just download this repository:
+
+`git clone https://github.com/giuliomagnifico/netatmo-exporter-full.git && cd netatmo-exporter-full`
+
+Create the Docker image:
+
+`docker build -t giuliomagnifico/netatmo-exporter-full:latest . `
+
+And run it (follow also the original instruction below):
+
+`docker volume create netatmo-token && docker run -d --name netatmo-exporter-full -p 9210:9210 -v netatmo-token:/var/lib/netatmo-exporter -e NETATMO_CLIENT_ID="xxx" -e NETATMO_CLIENT_SECRET="xxx" -e NETATMO_EXPORTER_EXTERNAL_URL="http://xxx:9210" giuliomagnifico/netatmo-exporter-full:latest`
+
+
 ---
 
 **⬇️ Below the original instructions ⬇️**

--- a/README.md
+++ b/README.md
@@ -1,3 +1,45 @@
+> ⚠️ **Warning**  
+ 
+This forked version of the Netatmo exporter for Prometheus also works with [Thermostat](https://www.netatmo.com/en-eu/smart-thermostat). You need to compile it, I haven't made a Docker build. It exposes three metrics:
+
+```
+netatmo_thermostat_boiler_status
+netatmo_thermostat_setpoint
+netatmo_thermostat_temperature
+```
+Full overview:
+
+```
+# HELP netatmo_thermostat_boiler_status Netatmo Energy boiler status (1=on, 0=off). Per-room when possibile, otherwise per-home.
+# TYPE netatmo_thermostat_boiler_status gauge
+netatmo_thermostat_boiler_status{home_id="60796ad062axx",home_name="Casa",room_id="",room_name=""} 0
+# HELP netatmo_thermostat_setpoint Netatmo Energy target setpoint temperature in degrees Celsius.
+# TYPE netatmo_thermostat_setpoint gauge
+netatmo_thermostat_setpoint{home_id="60796ad062xxx",home_name="Casa",room_id="3096xx",room_name=""} 0
+# HELP netatmo_thermostat_temperature Netatmo Energy measured room temperature in degrees Celsius.
+# TYPE netatmo_thermostat_temperature gauge
+netatmo_thermostat_temperature{home_id="60796ad062axxx",home_name="Casa",room_id="30964xxx",room_name=""} 17.9
+```
+
+You need to compile it by downloading this repo and build it using
+
+`go build -o netatmo-exporter`
+
+Then, as before (see below), the original instructions apply: generate the token on the Netatmo dev website and grant the token **read thermostat** access.
+
+Example in Grafana
+
+<img width="1796" height="1568" alt="510765545-ce94b4f1-3b09-426e-8713-eb90682ed892" src="https://github.com/user-attachments/assets/50103055-3fd8-4804-9980-a86d192dd222" />
+
+
+---
+
+**⬇️ Below the original instructions ⬇️**
+
+
+___
+
+
 # netatmo-exporter
 
 Simple [prometheus](https://prometheus.io) exporter for getting sensor values [NetAtmo](https://www.netatmo.com) sensors into prometheus.

--- a/internal/collector/thermostat.go
+++ b/internal/collector/thermostat.go
@@ -1,0 +1,251 @@
+package collector
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"net/http"
+
+	"github.com/prometheus/client_golang/prometheus"
+	"github.com/sirupsen/logrus"
+	"golang.org/x/oauth2"
+)
+
+var (
+	thermostatLabels = []string{"home_id", "home_name", "room_id", "room_name"}
+
+	thermostatTemperatureDesc = prometheus.NewDesc(
+		prefix+"thermostat_temperature",
+		"Netatmo Energy measured room temperature in degrees Celsius.",
+		thermostatLabels,
+		nil,
+	)
+
+	thermostatSetpointDesc = prometheus.NewDesc(
+		prefix+"thermostat_setpoint",
+		"Netatmo Energy target setpoint temperature in degrees Celsius.",
+		thermostatLabels,
+		nil,
+	)
+
+	thermostatBoilerStatusDesc = prometheus.NewDesc(
+		prefix+"thermostat_boiler_status",
+		"Netatmo Energy boiler status (1=on, 0=off). Per-room when possibile, otherwise per-home.",
+		thermostatLabels,
+		nil,
+	)
+)
+
+
+type ThermostatCollector struct {
+	log       logrus.FieldLogger
+	tokenFunc func() (*oauth2.Token, error)
+}
+
+func NewThermostatCollector(log logrus.FieldLogger, tokenFunc func() (*oauth2.Token, error)) *ThermostatCollector {
+	return &ThermostatCollector{
+		log:       log,
+		tokenFunc: tokenFunc,
+	}
+}
+
+func (c *ThermostatCollector) Describe(ch chan<- *prometheus.Desc) {
+	ch <- thermostatTemperatureDesc
+	ch <- thermostatSetpointDesc
+	ch <- thermostatBoilerStatusDesc
+}
+
+// Collect implementa prometheus.Collector.
+func (c *ThermostatCollector) Collect(ch chan<- prometheus.Metric) {
+	ctx := context.Background()
+
+	token, err := c.tokenFunc()
+	if err != nil {
+		c.log.Errorf("ThermostatCollector: error getting token: %v", err)
+		return
+	}
+	if token == nil || !token.Valid() {
+		c.log.Debug("ThermostatCollector: token not available or invalid, skipping collection.")
+		return
+	}
+
+	httpClient := oauth2.NewClient(ctx, oauth2.StaticTokenSource(token))
+
+	homes, err := fetchHomes(ctx, httpClient)
+	if err != nil {
+		c.log.Errorf("ThermostatCollector: error fetching homesdata: %v", err)
+		return
+	}
+
+	for _, home := range homes.Body.Homes {
+		status, err := fetchHomeStatus(ctx, httpClient, home.ID)
+		if err != nil {
+			c.log.Errorf("ThermostatCollector: error fetching homestatus for %s: %v", home.ID, err)
+			continue
+		}
+
+		h := status.Body.Home
+
+		homeID := h.ID
+		if homeID == "" {
+			homeID = home.ID
+		}
+
+		homeName := h.Name
+		if homeName == "" {
+			homeName = home.Name
+		}
+
+		boilerByRoom := map[string]float64{}
+		var homeBoiler *float64
+
+		for _, mod := range h.Modules {
+			if mod.BoilerStatus == nil {
+				continue
+			}
+
+			v := 0.0
+			if *mod.BoilerStatus {
+				v = 1.0
+			}
+
+			if mod.RoomID != "" {
+				boilerByRoom[mod.RoomID] = v
+			}
+
+			if homeBoiler == nil {
+				tmp := v
+				homeBoiler = &tmp
+			} else if v > *homeBoiler {
+				*homeBoiler = v
+			}
+		}
+
+		for _, room := range h.Rooms {
+			labels := []string{homeID, homeName, room.ID, room.Name}
+
+			if room.MeasuredTemperature != nil {
+				ch <- prometheus.MustNewConstMetric(
+					thermostatTemperatureDesc,
+					prometheus.GaugeValue,
+					*room.MeasuredTemperature,
+					labels...,
+				)
+			}
+
+			if room.SetpointTemperature != nil {
+				ch <- prometheus.MustNewConstMetric(
+					thermostatSetpointDesc,
+					prometheus.GaugeValue,
+					*room.SetpointTemperature,
+					labels...,
+				)
+			}
+
+			if val, ok := boilerByRoom[room.ID]; ok {
+				ch <- prometheus.MustNewConstMetric(
+					thermostatBoilerStatusDesc,
+					prometheus.GaugeValue,
+					val,
+					labels...,
+				)
+			}
+		}
+
+		if homeBoiler != nil {
+			labels := []string{homeID, homeName, "", ""}
+			ch <- prometheus.MustNewConstMetric(
+				thermostatBoilerStatusDesc,
+				prometheus.GaugeValue,
+				*homeBoiler,
+				labels...,
+			)
+		}
+	}
+}
+
+type homesDataResponse struct {
+	Body struct {
+		Homes []struct {
+			ID   string `json:"id"`
+			Name string `json:"name"`
+		} `json:"homes"`
+	} `json:"body"`
+}
+
+type homeStatusResponse struct {
+	Body struct {
+		Home struct {
+			ID      string        `json:"id"`
+			Name    string        `json:"name"`
+			Rooms   []roomStatus  `json:"rooms"`
+			Modules []moduleStatus `json:"modules"`
+		} `json:"home"`
+	} `json:"body"`
+}
+
+type roomStatus struct {
+	ID                  string   `json:"id"`
+	Name                string   `json:"name"`
+	MeasuredTemperature *float64 `json:"therm_measured_temperature"`
+	SetpointTemperature *float64 `json:"therm_setpoint_temperature"`
+}
+
+type moduleStatus struct {
+	ID           string `json:"id"`
+	Type         string `json:"type"`
+	RoomID       string `json:"room_id"`
+	BoilerStatus *bool  `json:"boiler_status,omitempty"`
+}
+
+func fetchHomes(ctx context.Context, client *http.Client) (*homesDataResponse, error) {
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, "https://api.netatmo.com/api/homesdata", nil)
+	if err != nil {
+		return nil, fmt.Errorf("creating homesdata request: %w", err)
+	}
+
+	resp, err := client.Do(req)
+	if err != nil {
+		return nil, fmt.Errorf("executing homesdata request: %w", err)
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusOK {
+		return nil, fmt.Errorf("homesdata request failed: status %s", resp.Status)
+	}
+
+	var result homesDataResponse
+	if err := json.NewDecoder(resp.Body).Decode(&result); err != nil {
+		return nil, fmt.Errorf("decoding homesdata response: %w", err)
+	}
+
+	return &result, nil
+}
+
+func fetchHomeStatus(ctx context.Context, client *http.Client, homeID string) (*homeStatusResponse, error) {
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, "https://api.netatmo.com/api/homestatus", nil)
+	if err != nil {
+		return nil, fmt.Errorf("creating homestatus request: %w", err)
+	}
+
+	q := req.URL.Query()
+	q.Set("home_id", homeID)
+	req.URL.RawQuery = q.Encode()
+
+	resp, err := client.Do(req)
+	if err != nil {
+		return nil, fmt.Errorf("executing homestatus request: %w", err)
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusOK {
+		return nil, fmt.Errorf("homestatus request failed: status %s", resp.Status)
+	}
+
+	var result homeStatusResponse
+	if err := json.NewDecoder(resp.Body).Decode(&result); err != nil {
+		return nil, fmt.Errorf("decoding homestatus response: %w", err)
+	}
+
+	return &result, nil
+}

--- a/main.go
+++ b/main.go
@@ -10,13 +10,13 @@ import (
 	"syscall"
 	"time"
 
+	netatmo "github.com/exzz/netatmo-api-go"
 	"github.com/prometheus/client_golang/prometheus"
 	"github.com/prometheus/client_golang/prometheus/promhttp"
 	"github.com/sirupsen/logrus"
 	"github.com/spf13/pflag"
 	"golang.org/x/oauth2"
 
-	"github.com/exzz/netatmo-api-go"
 	"github.com/xperimental/netatmo-exporter/v2/internal/collector"
 	"github.com/xperimental/netatmo-exporter/v2/internal/config"
 	"github.com/xperimental/netatmo-exporter/v2/internal/logger"
@@ -42,15 +42,17 @@ func main() {
 		log.Fatalf("Error in configuration: %s", err)
 	default:
 	}
-	log.SetLevel(logrus.Level(cfg.LogLevel))
 
+	log.SetLevel(logrus.Level(cfg.LogLevel))
 	log.Infof("netatmo-exporter %s (commit: %s)", Version, GitCommit)
+
 	client := netatmo.NewClient(cfg.Netatmo, tokenUpdated(cfg.TokenFile))
 
 	if cfg.TokenFile != "" {
 		token, err := loadToken(cfg.TokenFile)
 		switch {
 		case os.IsNotExist(err):
+			// no token file yet
 		case err != nil:
 			log.Fatalf("Error loading token: %s", err)
 		case !token.Expiry.IsZero() && token.Expiry.Before(time.Now()):
@@ -75,6 +77,9 @@ func main() {
 	metrics := collector.New(log, client.Read, cfg.RefreshInterval, cfg.StaleDuration)
 	prometheus.MustRegister(metrics)
 
+	thermostatMetrics := collector.NewThermostatCollector(log, client.CurrentToken)
+	prometheus.MustRegister(thermostatMetrics)
+
 	tokenMetric := token.Metric(client.CurrentToken)
 	prometheus.MustRegister(tokenMetric)
 
@@ -89,6 +94,7 @@ func main() {
 	http.Handle("/auth/authorize", web.AuthorizeHandler(cfg.ExternalURL, client))
 	http.Handle("/auth/callback", web.CallbackHandler(ctx, client))
 	http.Handle("/auth/settoken", web.SetTokenHandler(ctx, client))
+
 	http.Handle("/metrics", promhttp.HandlerFor(prometheus.DefaultGatherer, promhttp.HandlerOpts{}))
 	http.Handle("/version", versionHandler(log))
 	http.Handle("/", web.HomeHandler(client.CurrentToken))
@@ -115,9 +121,11 @@ func loadToken(fileName string) (*oauth2.Token, error) {
 func registerSignalHandler(client *netatmo.Client, fileName string) {
 	ch := make(chan os.Signal, 1)
 	signal.Notify(ch, signals...)
+
 	go func() {
 		sig := <-ch
 		signal.Reset(signals...)
+
 		log.Debugf("Got signal: %s", sig)
 
 		if err := saveToken(client, fileName); err != nil {
@@ -153,6 +161,7 @@ func saveToken(client *netatmo.Client, fileName string) error {
 	}
 
 	log.Infof("Saving token to %s ...", fileName)
+
 	return saveTokenFile(fileName, token)
 }
 

--- a/thermostat.go
+++ b/thermostat.go
@@ -1,0 +1,251 @@
+package collector
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"net/http"
+
+	"github.com/prometheus/client_golang/prometheus"
+	"github.com/sirupsen/logrus"
+	"golang.org/x/oauth2"
+)
+
+var (
+	thermostatLabels = []string{"home_id", "home_name", "room_id", "room_name"}
+
+	thermostatTemperatureDesc = prometheus.NewDesc(
+		prefix+"thermostat_temperature",
+		"Netatmo Energy measured room temperature in degrees Celsius.",
+		thermostatLabels,
+		nil,
+	)
+
+	thermostatSetpointDesc = prometheus.NewDesc(
+		prefix+"thermostat_setpoint",
+		"Netatmo Energy target setpoint temperature in degrees Celsius.",
+		thermostatLabels,
+		nil,
+	)
+
+	thermostatBoilerStatusDesc = prometheus.NewDesc(
+		prefix+"thermostat_boiler_status",
+		"Netatmo Energy boiler status (1=on, 0=off). Per-room when possibile, otherwise per-home.",
+		thermostatLabels,
+		nil,
+	)
+)
+
+
+type ThermostatCollector struct {
+	log       logrus.FieldLogger
+	tokenFunc func() (*oauth2.Token, error)
+}
+
+func NewThermostatCollector(log logrus.FieldLogger, tokenFunc func() (*oauth2.Token, error)) *ThermostatCollector {
+	return &ThermostatCollector{
+		log:       log,
+		tokenFunc: tokenFunc,
+	}
+}
+
+func (c *ThermostatCollector) Describe(ch chan<- *prometheus.Desc) {
+	ch <- thermostatTemperatureDesc
+	ch <- thermostatSetpointDesc
+	ch <- thermostatBoilerStatusDesc
+}
+
+// Collect implementa prometheus.Collector.
+func (c *ThermostatCollector) Collect(ch chan<- prometheus.Metric) {
+	ctx := context.Background()
+
+	token, err := c.tokenFunc()
+	if err != nil {
+		c.log.Errorf("ThermostatCollector: error getting token: %v", err)
+		return
+	}
+	if token == nil || !token.Valid() {
+		c.log.Debug("ThermostatCollector: token not available or invalid, skipping collection.")
+		return
+	}
+
+	httpClient := oauth2.NewClient(ctx, oauth2.StaticTokenSource(token))
+
+	homes, err := fetchHomes(ctx, httpClient)
+	if err != nil {
+		c.log.Errorf("ThermostatCollector: error fetching homesdata: %v", err)
+		return
+	}
+
+	for _, home := range homes.Body.Homes {
+		status, err := fetchHomeStatus(ctx, httpClient, home.ID)
+		if err != nil {
+			c.log.Errorf("ThermostatCollector: error fetching homestatus for %s: %v", home.ID, err)
+			continue
+		}
+
+		h := status.Body.Home
+
+		homeID := h.ID
+		if homeID == "" {
+			homeID = home.ID
+		}
+
+		homeName := h.Name
+		if homeName == "" {
+			homeName = home.Name
+		}
+
+		boilerByRoom := map[string]float64{}
+		var homeBoiler *float64
+
+		for _, mod := range h.Modules {
+			if mod.BoilerStatus == nil {
+				continue
+			}
+
+			v := 0.0
+			if *mod.BoilerStatus {
+				v = 1.0
+			}
+
+			if mod.RoomID != "" {
+				boilerByRoom[mod.RoomID] = v
+			}
+
+			if homeBoiler == nil {
+				tmp := v
+				homeBoiler = &tmp
+			} else if v > *homeBoiler {
+				*homeBoiler = v
+			}
+		}
+
+		for _, room := range h.Rooms {
+			labels := []string{homeID, homeName, room.ID, room.Name}
+
+			if room.MeasuredTemperature != nil {
+				ch <- prometheus.MustNewConstMetric(
+					thermostatTemperatureDesc,
+					prometheus.GaugeValue,
+					*room.MeasuredTemperature,
+					labels...,
+				)
+			}
+
+			if room.SetpointTemperature != nil {
+				ch <- prometheus.MustNewConstMetric(
+					thermostatSetpointDesc,
+					prometheus.GaugeValue,
+					*room.SetpointTemperature,
+					labels...,
+				)
+			}
+
+			if val, ok := boilerByRoom[room.ID]; ok {
+				ch <- prometheus.MustNewConstMetric(
+					thermostatBoilerStatusDesc,
+					prometheus.GaugeValue,
+					val,
+					labels...,
+				)
+			}
+		}
+
+		if homeBoiler != nil {
+			labels := []string{homeID, homeName, "", ""}
+			ch <- prometheus.MustNewConstMetric(
+				thermostatBoilerStatusDesc,
+				prometheus.GaugeValue,
+				*homeBoiler,
+				labels...,
+			)
+		}
+	}
+}
+
+type homesDataResponse struct {
+	Body struct {
+		Homes []struct {
+			ID   string `json:"id"`
+			Name string `json:"name"`
+		} `json:"homes"`
+	} `json:"body"`
+}
+
+type homeStatusResponse struct {
+	Body struct {
+		Home struct {
+			ID      string        `json:"id"`
+			Name    string        `json:"name"`
+			Rooms   []roomStatus  `json:"rooms"`
+			Modules []moduleStatus `json:"modules"`
+		} `json:"home"`
+	} `json:"body"`
+}
+
+type roomStatus struct {
+	ID                  string   `json:"id"`
+	Name                string   `json:"name"`
+	MeasuredTemperature *float64 `json:"therm_measured_temperature"`
+	SetpointTemperature *float64 `json:"therm_setpoint_temperature"`
+}
+
+type moduleStatus struct {
+	ID           string `json:"id"`
+	Type         string `json:"type"`
+	RoomID       string `json:"room_id"`
+	BoilerStatus *bool  `json:"boiler_status,omitempty"`
+}
+
+func fetchHomes(ctx context.Context, client *http.Client) (*homesDataResponse, error) {
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, "https://api.netatmo.com/api/homesdata", nil)
+	if err != nil {
+		return nil, fmt.Errorf("creating homesdata request: %w", err)
+	}
+
+	resp, err := client.Do(req)
+	if err != nil {
+		return nil, fmt.Errorf("executing homesdata request: %w", err)
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusOK {
+		return nil, fmt.Errorf("homesdata request failed: status %s", resp.Status)
+	}
+
+	var result homesDataResponse
+	if err := json.NewDecoder(resp.Body).Decode(&result); err != nil {
+		return nil, fmt.Errorf("decoding homesdata response: %w", err)
+	}
+
+	return &result, nil
+}
+
+func fetchHomeStatus(ctx context.Context, client *http.Client, homeID string) (*homeStatusResponse, error) {
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, "https://api.netatmo.com/api/homestatus", nil)
+	if err != nil {
+		return nil, fmt.Errorf("creating homestatus request: %w", err)
+	}
+
+	q := req.URL.Query()
+	q.Set("home_id", homeID)
+	req.URL.RawQuery = q.Encode()
+
+	resp, err := client.Do(req)
+	if err != nil {
+		return nil, fmt.Errorf("executing homestatus request: %w", err)
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusOK {
+		return nil, fmt.Errorf("homestatus request failed: status %s", resp.Status)
+	}
+
+	var result homeStatusResponse
+	if err := json.NewDecoder(resp.Body).Decode(&result); err != nil {
+		return nil, fmt.Errorf("decoding homestatus response: %w", err)
+	}
+
+	return &result, nil
+}


### PR DESCRIPTION
Hi, I added these thermostat metrics:

```
netatmo_thermostat_boiler_status
netatmo_thermostat_setpoint
netatmo_thermostat_temperature
```

Works fine for me (and my thermostat, of course), but review the code...I vibe coded it without spending much time on reading all the API documents 😅
PS: Unfortunately I don’t have the valves to test with, so I didn’t include those metrics.


```
# HELP netatmo_thermostat_boiler_status Netatmo Energy boiler status (1=on, 0=off). Per-room when possibile, otherwise per-home.
# TYPE netatmo_thermostat_boiler_status gauge
netatmo_thermostat_boiler_status{home_id="60796ad062axx",home_name="Casa",room_id="",room_name=""} 0
# HELP netatmo_thermostat_setpoint Netatmo Energy target setpoint temperature in degrees Celsius.
# TYPE netatmo_thermostat_setpoint gauge
netatmo_thermostat_setpoint{home_id="60796ad062xxx",home_name="Casa",room_id="3096xx",room_name=""} 0
# HELP netatmo_thermostat_temperature Netatmo Energy measured room temperature in degrees Celsius.
# TYPE netatmo_thermostat_temperature gauge
netatmo_thermostat_temperature{home_id="60796ad062axxx",home_name="Casa",room_id="30964xxx",room_name=""} 17.9
```
<img width="1796" height="1568" alt="CleanShot 2025-11-06 at 13 34 36" src="https://github.com/user-attachments/assets/ce94b4f1-3b09-426e-8713-eb90682ed892" />

